### PR TITLE
First pass at OBJ format import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS 	+=
 
 CXXFLAGS	+=	-Wall  -std=c++11 $(OPTFLAGS) -I/opt/local/include/
 
-SOURCES         = ray.cpp world.cpp
+SOURCES         = ray.cpp world.cpp obj-support.cpp
 
 OBJECTS         = $(SOURCES:.cpp=.o)
 

--- a/obj-support.cpp
+++ b/obj-support.cpp
@@ -1,0 +1,335 @@
+#include "obj-support.h"
+#include "world.h"
+#include <string>
+#include <vector>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+// Parsing helpers
+namespace
+{
+
+template<typename T>
+static T
+fromString(const std::string& asString)
+{
+    std::stringstream ss(asString);
+    T retVal = T();
+    ss >> retVal;
+    return retVal;
+}
+
+template<typename T>
+static std::string
+toString(const T t)
+{
+    std::stringstream ss;
+    ss << t;
+    return ss.str();
+}
+
+void split_tuple_exact(const std::string& tuple, char delimiter, std::vector<std::string>& elements)
+{
+    std::stringstream ss(tuple);
+    std::string item;
+    while (std::getline(ss, item, delimiter))
+    {
+        elements.push_back(item);
+    }
+}
+
+void split_tuple_fuzzy(const std::string& tuple, char delimiter, std::vector<std::string>& elements)
+{
+    // For a fuzzy split, we want to add whitespace to the base delimiter
+    std::string fuzzyDelimiter(" ");
+    fuzzyDelimiter += delimiter;
+
+    std::string::size_type startPos(0);
+    std::string item(tuple);
+    std::string::size_type endPos = item.find_first_of(fuzzyDelimiter);
+    while (endPos != std::string::npos)
+    {
+        // We found at least one instance of something from the fuzzy delimiter
+        // cut/paste the initial item and find the next one (if any)
+        elements.push_back(std::string(item, startPos, endPos - startPos));
+        std::string::size_type nextPos = item.find_first_not_of(fuzzyDelimiter, endPos);
+        item = item.erase(startPos, nextPos - startPos);
+        endPos = item.find_first_of(fuzzyDelimiter);
+    }
+
+    // As long as 'tuple' had at least one element in it, 'item' will contain
+    // the final one at this point.
+    elements.push_back(item);
+}
+
+} // Anonymous namespace
+
+const std::string Obj::object_description("o");
+const std::string Obj::vertex_description("v");
+const std::string Obj::normal_description("vn");
+const std::string Obj::texcoord_description("vt");
+const std::string Obj::face_description("f");
+
+const unsigned int Obj::FACE_ATTRIB_NONE = 0;
+const unsigned int Obj::FACE_ATTRIB_POSITION = 0x1;
+const unsigned int Obj::FACE_ATTRIB_NORMAL = 0x2;
+const unsigned int Obj::FACE_ATTRIB_TEXCOORD = 0x4;
+
+Obj::Obj()
+{
+}
+
+Obj::~Obj()
+{
+}
+
+void Obj::compute_normals()
+{
+    normals.resize(positions.size(), vec3(0.0));
+
+    for (auto & face : faces)
+    {
+        // Compute the area-weighted face normal for this face
+        vec3& v0 = positions[face.v0];
+        vec3& v1 = positions[face.v1];
+        vec3& v2 = positions[face.v2];
+        vec3 fn = cross(v1 - v0, v2 - v0);
+        float area = 0.5 * sqrt(dot(fn, fn));
+        fn = fn * area;
+
+        // Accumulate the per-vertex contribution of the normal
+        face.which_attribs |= FACE_ATTRIB_NORMAL;
+        face.vn0 = face.v0;
+        face.vn1 = face.v1;
+        face.vn2 = face.v2;
+
+        vec3& vn0 = normals[face.vn0];
+        vec3& vn1 = normals[face.vn1];
+        vec3& vn2 = normals[face.vn2];
+
+        vn0 = vn0 + fn;
+        vn1 = vn1 + fn;
+        vn2 = vn2 + fn;
+    }
+
+    for (auto & normal : normals)
+    {
+        normal = normalize(normal);
+    }
+}
+
+void Obj::get_attrib(const std::string& description, vec3& v)
+{
+    // Vertex attributes are whitespace separated, so use fuzzy split
+    std::vector<std::string> elements;
+    split_tuple_fuzzy(description, ' ', elements);
+
+    unsigned int numElements = elements.size();
+    switch (numElements)
+    {
+        case 3:
+            v.z = fromString<float>(elements[2]);
+        case 2:
+            v.y = fromString<float>(elements[1]);
+        case 1:
+            v.x = fromString<float>(elements[0]);
+            break;
+        default:
+            std::cerr << "Trying to handle tuple with " << numElements
+                << " elements!" << std::endl;
+            break;
+    }
+}
+
+void Obj::face_get_index(const std::string& tuple, unsigned int& which_attribs,
+    unsigned int& v, unsigned int& vn, unsigned int& vt)
+{
+    // Attribute indices within a face description require no spaces around
+    // the '/', so use an exact split
+    std::vector<std::string> elements;
+    split_tuple_exact(tuple, '/', elements);
+
+    which_attribs = FACE_ATTRIB_NONE;
+    if (elements.empty())
+    {
+        return;
+    }
+
+    which_attribs |= FACE_ATTRIB_POSITION;
+    v = fromString<unsigned int>(elements[0]);
+
+    unsigned int numElements = elements.size();
+
+    if (numElements > 1 && !elements[1].empty())
+    {
+        which_attribs |= FACE_ATTRIB_TEXCOORD;
+        vt = fromString<unsigned int>(elements[1]);
+    }
+
+    if (numElements > 2 && !elements[2].empty())
+    {
+        which_attribs |= FACE_ATTRIB_NORMAL;
+        vn = fromString<unsigned int>(elements[2]);
+    }
+}
+
+void Obj::get_face(const std::string& description, Face& f)
+{
+    // Tuples of indices are whitespace separated, so use fuzzy split
+    // (e.g., "f v/vt/vn v/vt/vn v/vt/vn ...")
+    std::vector<std::string> elements;
+    split_tuple_fuzzy(description, ' ', elements);
+
+    unsigned int which_attribs(FACE_ATTRIB_NONE);
+    unsigned int v0(0);
+    unsigned int vt0(0);
+    unsigned int vn0(0);
+    face_get_index(elements[0], which_attribs, v0, vn0, vt0);
+
+    unsigned int v1(0);
+    unsigned int vt1(0);
+    unsigned int vn1(0);
+    face_get_index(elements[1], which_attribs, v1, vn1, vt1);
+ 
+    unsigned int v2(0);
+    unsigned int vt2(0);
+    unsigned int vn2(0);
+    face_get_index(elements[2], which_attribs, v2, vn2, vt2);
+
+    // However we end up stashing face information, it is important to account
+    // for the fact that OBJ models have a base 1 (rather than base 0) index
+    // enumeration, so each index needs to have 1 subtracted.
+    f.which_attribs = which_attribs;
+    f.v0 = v0 - 1;
+    f.v1 = v1 - 1;
+    f.v2 = v2 - 1;
+    if (which_attribs & FACE_ATTRIB_NORMAL)
+    {
+        f.vn0 = vn0 - 1;
+        f.vn1 = vn1 - 1;
+        f.vn2 = vn2 - 1;
+    }
+    if (which_attribs & FACE_ATTRIB_TEXCOORD)
+    {
+        f.vt0 = vt0 - 1;
+        f.vt1 = vt1 - 1;
+        f.vt2 = vt2 - 1;
+    }
+}
+
+bool Obj::load_object_from_file(const std::string& filename)
+{
+    // Open the file, get an input stream
+    std::ifstream inputFile(filename);
+    if (!inputFile.is_open())
+    {
+        // Complain about open fail
+        return false;
+    }
+
+    // Scan in the source lines
+    std::vector<std::string> sourceLines;
+    std::string curLine;
+    while (getline(inputFile, curLine))
+    {
+        sourceLines.push_back(curLine);
+    }
+
+    // Process the input source and generate lists of attributes and faces
+    for (auto & lineIt : sourceLines)
+    {
+        // Find what sort of description we're looking at on the current line
+        // We are currently ignoring everything other than vertex attributes
+        // and face descriptions.
+        const std::string& curDesc = lineIt;
+        std::string::size_type startPos(0);
+        std::string::size_type spacePos = curDesc.find(" ", startPos);
+        std::string::size_type numChars(std::string::npos);
+        std::string description;
+        if (spacePos != std::string::npos)
+        {
+            // Absorb any whitespace between the description type and the data
+            std::string::size_type descPos = curDesc.find_first_not_of(' ', spacePos);
+            description = std::string(curDesc, descPos);
+            numChars = spacePos - startPos;
+        }
+        std::string descriptionType(curDesc, startPos, numChars);
+
+        if (descriptionType == object_description)
+        {
+            std::cout << "Found object '" << description << "'" << std::endl;
+        }
+        else if (descriptionType == vertex_description)
+        {
+            vec3 p(0);
+            get_attrib(description, p);
+            positions.push_back(p);
+        }
+        else if (descriptionType == normal_description)
+        {
+            vec3 n(0);
+            get_attrib(description, n);
+            normals.push_back(n);
+        }
+        else if (descriptionType == texcoord_description)
+        {
+            vec3 t(0);
+            get_attrib(description, t);
+            texcoords.push_back(t);
+        }
+        else if (descriptionType == face_description)
+        {
+            Face f = {0};
+            get_face(description, f);
+            faces.push_back(f);
+        }
+        else
+        {
+            std::cout << "Unrecognized description '" << description << "'" << std::endl;
+        }
+    }
+
+    std::cout << "Got " << faces.size() << " face descriptions" << std::endl;
+    std::cout << "Got " << positions.size() << " vertex descriptions" << std::endl;
+    if (!normals.empty())
+    {
+        std::cout << "Got " << normals.size() << " normal descriptions" << std::endl;
+    }
+    else
+    {
+        std::cout << "Generating normals..." << std::endl;
+        compute_normals();
+    }
+
+    if (!texcoords.empty())
+    {
+        std::cout << "Got " << texcoords.size() << "texcoord descriptions" << std::endl;
+    }
+
+    return true;
+}
+
+bool Obj::fill_triangle_set(triangle_set& triangles)
+{
+    // Convert from face-vertex mesh to list of triangles
+    for (auto & faceIt : faces)
+    {
+        const Face& face = faceIt;
+        vertex vtx[3];
+        vtx[0].v = positions[face.v0];
+        vtx[1].v = positions[face.v1];
+        vtx[2].v = positions[face.v2];
+        if (face.which_attribs & FACE_ATTRIB_NORMAL)
+        {
+            vtx[0].n = normals[face.vn0];
+            vtx[1].n = normals[face.vn1];
+            vtx[2].n = normals[face.vn2];
+        }
+        vtx[0].c = vtx[1].c = vtx[2].c = vec3(1.0, 1.0, 1.0);
+        triangles.add(vtx[0], vtx[1], vtx[2]);
+    }
+
+    return true;
+}
+

--- a/obj-support.h
+++ b/obj-support.h
@@ -1,0 +1,61 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "vectormath.h"
+
+//
+// OBJ file format - https://en.wikipedia.org/wiki/Wavefront_.obj_file
+//
+// Quick summary: ASCII file describing a 3D mesh.  Each line describes
+//                a single vertex attribute or face of a triangle.
+//
+//
+struct triangle_set;
+class Obj
+{
+    struct Face
+    {
+        unsigned int which_attribs;
+        unsigned int v0;
+        unsigned int v1;
+        unsigned int v2;
+        unsigned int vn0;
+        unsigned int vn1;
+        unsigned int vn2;
+        unsigned int vt0;
+        unsigned int vt1;
+        unsigned int vt2;
+    };
+
+    void get_attrib(const std::string& description, vec3& v);
+    void get_face(const std::string& description, Face& f);
+    void face_get_index(const std::string& tuple, unsigned int& which_attribs,
+                        unsigned int& v, unsigned int& vn, unsigned int& vt);
+    void compute_normals();
+
+    std::vector<vec3> positions;
+    std::vector<vec3> normals;
+    std::vector<vec3> texcoords;
+    std::vector<Face> faces;
+
+    // There may be more of these (certainly more tokens are defined
+    // for OBJ files in general), but this should get us going and
+    // we can emit a notification when we hit an undefined type.
+    static const std::string object_description;
+    static const std::string vertex_description;
+    static const std::string normal_description;
+    static const std::string texcoord_description;
+    static const std::string face_description;
+
+    static const unsigned int FACE_ATTRIB_NONE;
+    static const unsigned int FACE_ATTRIB_POSITION;
+    static const unsigned int FACE_ATTRIB_NORMAL;
+    static const unsigned int FACE_ATTRIB_TEXCOORD;
+
+public:
+    Obj();
+    ~Obj();
+
+    bool load_object_from_file(const std::string& filename);
+    bool fill_triangle_set(triangle_set& triangles);
+};

--- a/vectormath.h
+++ b/vectormath.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <cmath>
 #include <algorithm>
 


### PR DESCRIPTION
This adds a rudimentary OBJ loader.
It computes weighted vertex normals (there is a likely superfluous computation during the accumulation of the normals that I'm happy to remove) if none are provided by the model.
Switching between current loading and OBJ loading is a compile-time switch that could easily be converted to environment and/or other runtime based mechanism.
It is also possible that there is a cleaner way to get from the face-vertex layout from the OBJ file to the internal triangle_set, but I was looking to keep the changes "minimal".